### PR TITLE
enforced jwt for all non-public routes

### DIFF
--- a/.env
+++ b/.env
@@ -33,10 +33,10 @@
 # LAN_IP=10.12.243.7 (school)
 # LAN_IP=192.168.1.248 (Juan)
 # LAN_IP=192.168.1.150 (Yulia)
-# LAN_IP=192.168.1.207 - 37.28.234.250 (Camille Asus)
-# LAN_IP=192.168.0.152 (Tina)
+# LAN_IP=192.168.1.207 (Camille Asus)
+# LAN_IP=192.168.1.207 (Tina)
 # ============================================================================
-LAN_IP=192.168.0.152
+LAN_IP=192.168.1.207
 
 # Auth Service (authentication, JWT, login/signup)
 AUTH_SERVICE_PORT=3001


### PR DESCRIPTION
Enforced JWT protection for all non-public routes -> ensures compliance with subject line

> _"For instance, if you choose to create an API, ensure your routes are protected"_

on page 10.

### File changes:

**1. `.env*`*
- removed the incorrect IP in comments for my Asus pc

**2. - `backend/gateway/main.js`**
- Created an array of paths to exempt from jwt protection
- Enforced `jwtVerify` on the rest of paths